### PR TITLE
Add pre-commit config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: cblack
+  name: cblack
+  description: "Black: The uncompromising Python code formatter - 2 space indent fork"
+  entry: cblack --check
+  language: python
+  language_version: python3
+  require_serial: true
+  types: [python]
+


### PR DESCRIPTION
This allows using the cblack repository as [pre-commit](https://pre-commit.com/) hook, with the following configuration:

```
repos:
-   repo: https://github.com/pausan/cblack.git
    rev: master
    hooks:
    -   id: cblack
```