### PR TITLE
Update black requirement to 22.3.0

### DIFF
--- a/cblack.py
+++ b/cblack.py
@@ -11,7 +11,7 @@ except ImportError:
   import black
 
 
-__version__ = "21.6b0"
+__version__ = "22.3.0"
 
 _orgLineStr = black.Line.__str__
 _orgFixDocString = black.fix_docstring

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     package_data={},
     python_requires=">=3.6.2",
     zip_safe=False,
-    install_requires=["black==21.6b0"],
+    install_requires=["black==22.3.0"],
     extras_require={},
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -52,6 +52,9 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Software Development :: Quality Assurance",


### PR DESCRIPTION
Tested with Python 3.7 and also 3.10 with a file containing the 3.10 "match" statement:

```bash
% python3.10 -m cblack --diff test.py
--- test.py	2022-04-02 21:22:42.638572 +0000
+++ test.py	2022-04-04 15:09:32.367182 +0000
@@ -1,14 +1,14 @@
 import argparse
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument('command', choices=['push', 'pull', 'commit'])
+parser.add_argument("command", choices=["push", "pull", "commit"])
 args = parser.parse_args()
 
 match args.command:
-    case 'push':
-        print('pushing')
-    case 'pull':
-        print('pulling')
-    case _:
-        parser.error(f'{args.command!r} not yet implemented')
+  case "push":
+    print("pushing")
+  case "pull":
+    print("pulling")
+  case _:
+    parser.error(f"{args.command!r} not yet implemented")
would reformat /Users/lluce/workspace/source/test.py

All done! ✨ 🍰 ✨
1 file would be reformatted.
```