### PR TITLE
rationalize the metapath finder

### DIFF
--- a/cblack.py
+++ b/cblack.py
@@ -40,9 +40,9 @@ class CBlackModuleLoader(type(_real_pathfinder)):
     """ """
     spec = _real_pathfinder.find_spec(fullname, path)
     if (
-      spec
-      and (CBlackModuleLoader._black_folder in spec.origin)
-      and spec.origin.endswith(".so")
+        spec
+        and (CBlackModuleLoader._black_folder in spec.origin)
+        and spec.origin.endswith(".so")
     ):
       # replace known dynamic loader module extensions by their "py" counterpart
       location = spec.origin

--- a/cblack.py
+++ b/cblack.py
@@ -67,10 +67,11 @@ try:
   import black.linegen as black_line
   from black import main as black_main
 except ImportError:
-  print("Cannot import black. Have you installed black v%s?" % __version__)
+  raise ImportError("Cannot import black. Have you installed black v%s?" % __version__)
 
 _orgLineStr = black_line.Line.__str__
 _orgFixDocString = black_str.fix_docstring
+_orgBracketSplit = black_line.bracket_split_build_line
 
 
 def lineStrIndentTwoSpaces(self) -> str:
@@ -94,9 +95,17 @@ def fixDocString(docstring, prefix):
   return _orgFixDocString(docstring, " " * (len(prefix) >> 1))
 
 
+def bracketSplitBuildLine(*args, is_body: bool = False, **kwargs):
+  result = _orgBracketSplit(*args, **kwargs, is_body=is_body)
+  if is_body:
+    result.depth += 1
+  return result
+
+
 # Patch original black formatter function
 black_line.Line.__str__ = lineStrIndentTwoSpaces
 black_line.fix_docstring = fixDocString
+black_line.bracket_split_build_line = bracketSplitBuildLine
 black_str.fix_docstring = fixDocString
 
 

--- a/cblack.py
+++ b/cblack.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
+import contextlib
 import re
 import sys
 
@@ -9,58 +10,69 @@ import sys
 from os.path import isdir
 
 import importlib
+import importlib.abc
 import importlib.util
 import importlib.machinery
 
 
-_real_pathfinder = sys.meta_path[-1]
+@contextlib.contextmanager
+def prevent_metapath_recursion(cls):
+  orig_meta_path = tuple(sys.meta_path)
+  while cls in sys.meta_path:
+    sys.meta_path.remove(cls)
+  yield
+  sys.meta_path[:] = orig_meta_path
 
 
-class CBlackModuleLoader(type(_real_pathfinder)):
+class MonkeypatchEnablingBlackModuleFinder(importlib.abc.MetaPathFinder):
   """
-  This custom module loader is used in order to prevent black to load a
-  dynamic library as the module, and load the python module instead.
+  This custom module finder is used in order to prevent black to load a
+  binary as the module, and load the pure-python module instead.
 
   This is done for the later black monkeypatching to work. Otherwise binaries
   cannot be patched.
-
-  Please note that this should not prevent other libraries from loading their
-  dynamic library modules. So everything will load as expected but black module.
 
   Reference:
     https://stupidpythonideas.blogspot.com/2015/06/hacking-python-without-hacking-python.html
   """
 
-  # all "black" folders contain the substring "/black-<version>"
-  # (e.g "/usr/local/lib/python3.8/site-packages/black-22.3.0-py3.8-linux-x86_64.egg")
-  _black_folder = "/black-%s" % __version__
-
   @classmethod
-  def find_module(cls, fullname, path=None):
+  def find_spec(cls, fullname, path, target=None):
     """ """
-    spec = _real_pathfinder.find_spec(fullname, path)
-    if (
-        spec
-        and (CBlackModuleLoader._black_folder in spec.origin)
-        and spec.origin.endswith(".so")
+    if fullname not in (
+        # only need to monkeypatch those two modules
+        "black.strings",
+        "black.linegen",
+        # segfault if we don't also pythonize the parent `black` module
+        "black",
     ):
-      # replace known dynamic loader module extensions by their "py" counterpart
-      location = spec.origin
-      for ext in importlib.machinery.EXTENSION_SUFFIXES:
-        if location.endswith(ext):
-          location = location.replace(ext, ".py")
-          break
+      return None
 
-      # load & replace the spec from the python file
-      spec = importlib.util.spec_from_file_location(spec.name, location)
+    # find what the spec "would have been" without this finder
+    with prevent_metapath_recursion(cls):
+      # I wasn't able to find a public api for this:
+      spec = importlib._bootstrap._find_spec(fullname, path)
 
-    if not spec:
+    if not (spec and spec.origin):
+      # we only care if the other finders found a .so
       return spec
-    return spec.loader
+
+    # replace known dynamic loader module extensions by their "py" counterpart
+    for ext in importlib.machinery.EXTENSION_SUFFIXES:
+      if spec.origin.endswith(ext):
+
+        py_path = spec.origin.replace(ext, ".py")
+
+        # try to load & replace the spec from the .py path
+        py_spec = importlib.util.spec_from_file_location(spec.name, py_path)
+        if py_spec:
+          return py_spec
+    else:
+      return spec
 
 
-# Replace the real module loader by our own
-sys.meta_path[-1] = CBlackModuleLoader
+# override the usual module loaders with our own
+sys.meta_path.insert(0, MonkeypatchEnablingBlackModuleFinder)
 
 try:
   import black.strings as black_str

--- a/test/3.10_expected.py
+++ b/test/3.10_expected.py
@@ -8,28 +8,28 @@ accordingly.
 """
 
 from x import (
-  a,
-  b,
-  c,
+    a,
+    b,
+    c,
 )
 
 
 A_GLOBAL_SET = {
-  # a comment
-  # another comment
-  "a string",
-  "another string",
-  # another comment
-  "yet another string",
+    # a comment
+    # another comment
+    "a string",
+    "another string",
+    # another comment
+    "yet another string",
 }
 
 
 def lookAtThisMethod(
-  first_parameter,
-  second_paramter=None,
-  third_parameter=32,
-  fourth_parameter="a short string as default argument",
-  **kwargs
+    first_parameter,
+    second_paramter=None,
+    third_parameter=32,
+    fourth_parameter="a short string as default argument",
+    **kwargs
 ):
   """The point of this is see how it reformats parameters
 
@@ -40,10 +40,10 @@ def lookAtThisMethod(
   We are done!
   """
   return kwargs["whatever"](
-    first_parameter * third_parameter,
-    second_paramter,
-    fourth_parameter,
-    "extra string because I want to",
+      first_parameter * third_parameter,
+      second_paramter,
+      fourth_parameter,
+      "extra string because I want to",
   )
 
 
@@ -56,16 +56,16 @@ def main():
     raise app.UsageError("Too many command-line arguments.")
 
   x = (
-    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
-    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
   )
 
   y = [
-    1,
-    2,
-    [
-      3,
-    ],
+      1,
+      2,
+      [
+          3,
+      ],
   ]
 
   match len(argv):
@@ -81,18 +81,18 @@ def main():
       print("more args")
 
   z = {
-    "another": "map",
-    "of": 3,
-    "values": [
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-    ],
+      "another": "map",
+      "of": 3,
+      "values": [
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+      ],
   }
 
 

--- a/test/3.7_expected.py
+++ b/test/3.7_expected.py
@@ -8,28 +8,28 @@ accordingly.
 """
 
 from x import (
-  a,
-  b,
-  c,
+    a,
+    b,
+    c,
 )
 
 
 A_GLOBAL_SET = {
-  # a comment
-  # another comment
-  "a string",
-  "another string",
-  # another comment
-  "yet another string",
+    # a comment
+    # another comment
+    "a string",
+    "another string",
+    # another comment
+    "yet another string",
 }
 
 
 def lookAtThisMethod(
-  first_parameter,
-  second_paramter=None,
-  third_parameter=32,
-  fourth_parameter="a short string as default argument",
-  **kwargs
+    first_parameter,
+    second_paramter=None,
+    third_parameter=32,
+    fourth_parameter="a short string as default argument",
+    **kwargs
 ):
   """The point of this is see how it reformats parameters
 
@@ -40,10 +40,10 @@ def lookAtThisMethod(
   We are done!
   """
   return kwargs["whatever"](
-    first_parameter * third_parameter,
-    second_paramter,
-    fourth_parameter,
-    "extra string because I want to",
+      first_parameter * third_parameter,
+      second_paramter,
+      fourth_parameter,
+      "extra string because I want to",
   )
 
 
@@ -56,31 +56,31 @@ def main():
     raise app.UsageError("Too many command-line arguments.")
 
   x = (
-    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
-    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
   )
 
   y = [
-    1,
-    2,
-    [
-      3,
-    ],
+      1,
+      2,
+      [
+          3,
+      ],
   ]
 
   z = {
-    "another": "map",
-    "of": 3,
-    "values": [
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-    ],
+      "another": "map",
+      "of": 3,
+      "values": [
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+      ],
   }
 
 

--- a/test/3.8_expected.py
+++ b/test/3.8_expected.py
@@ -8,28 +8,28 @@ accordingly.
 """
 
 from x import (
-  a,
-  b,
-  c,
+    a,
+    b,
+    c,
 )
 
 
 A_GLOBAL_SET = {
-  # a comment
-  # another comment
-  "a string",
-  "another string",
-  # another comment
-  "yet another string",
+    # a comment
+    # another comment
+    "a string",
+    "another string",
+    # another comment
+    "yet another string",
 }
 
 
 def lookAtThisMethod(
-  first_parameter,
-  second_paramter=None,
-  third_parameter=32,
-  fourth_parameter="a short string as default argument",
-  **kwargs
+    first_parameter,
+    second_paramter=None,
+    third_parameter=32,
+    fourth_parameter="a short string as default argument",
+    **kwargs
 ):
   """The point of this is see how it reformats parameters
 
@@ -40,10 +40,10 @@ def lookAtThisMethod(
   We are done!
   """
   return kwargs["whatever"](
-    first_parameter * third_parameter,
-    second_paramter,
-    fourth_parameter,
-    "extra string because I want to",
+      first_parameter * third_parameter,
+      second_paramter,
+      fourth_parameter,
+      "extra string because I want to",
   )
 
 
@@ -56,31 +56,31 @@ def main():
     raise app.UsageError("Too many command-line arguments.")
 
   x = (
-    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
-    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
   )
 
   y = [
-    1,
-    2,
-    [
-      3,
-    ],
+      1,
+      2,
+      [
+          3,
+      ],
   ]
 
   z = {
-    "another": "map",
-    "of": 3,
-    "values": [
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-    ],
+      "another": "map",
+      "of": 3,
+      "values": [
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+      ],
   }
 
 

--- a/test/3.9_expected.py
+++ b/test/3.9_expected.py
@@ -8,28 +8,28 @@ accordingly.
 """
 
 from x import (
-  a,
-  b,
-  c,
+    a,
+    b,
+    c,
 )
 
 
 A_GLOBAL_SET = {
-  # a comment
-  # another comment
-  "a string",
-  "another string",
-  # another comment
-  "yet another string",
+    # a comment
+    # another comment
+    "a string",
+    "another string",
+    # another comment
+    "yet another string",
 }
 
 
 def lookAtThisMethod(
-  first_parameter,
-  second_paramter=None,
-  third_parameter=32,
-  fourth_parameter="a short string as default argument",
-  **kwargs
+    first_parameter,
+    second_paramter=None,
+    third_parameter=32,
+    fourth_parameter="a short string as default argument",
+    **kwargs
 ):
   """The point of this is see how it reformats parameters
 
@@ -40,10 +40,10 @@ def lookAtThisMethod(
   We are done!
   """
   return kwargs["whatever"](
-    first_parameter * third_parameter,
-    second_paramter,
-    fourth_parameter,
-    "extra string because I want to",
+      first_parameter * third_parameter,
+      second_paramter,
+      fourth_parameter,
+      "extra string because I want to",
   )
 
 
@@ -56,31 +56,31 @@ def main():
     raise app.UsageError("Too many command-line arguments.")
 
   x = (
-    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
-    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
   )
 
   y = [
-    1,
-    2,
-    [
-      3,
-    ],
+      1,
+      2,
+      [
+          3,
+      ],
   ]
 
   z = {
-    "another": "map",
-    "of": 3,
-    "values": [
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-      12345678,
-    ],
+      "another": "map",
+      "of": 3,
+      "values": [
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+          12345678,
+      ],
   }
 
 


### PR DESCRIPTION
It's not true that "all "black" folders contain the substring
"/black-<version>"".  That's only true when using `pip install -e
./path/to/black` which is in general a rare use case. I've modified the
finder to be more robust to differences in installation methods.